### PR TITLE
Apply theme to custom_words_raw and log_text widgets

### DIFF
--- a/src/frontend/constants.py
+++ b/src/frontend/constants.py
@@ -13,6 +13,8 @@ THEMES = {
         "fg": "#333333",          # Primary text color (dark gray)
         "button_bg": "#A5D9F1",   # Default button background (light blue)
         "active_bg": "#6CA0B8",   # Active/selected button background (medium blue)
+        "console_fg":"#333333",   # Text color in console (black)
+        "console_bg":"#F5F5F5",   # Main background color in console (light gray always)
         "active_fg": "#000000",   # Text color for active elements (black)
         "message": "#00707D",     # Notification/copy confirmation color (teal blue)
     },
@@ -22,6 +24,8 @@ THEMES = {
         "fg": "#FFFFFF",          # Primary text color (white)
         "button_bg": "#3C8DBC",   # Default button background (medium blue)
         "active_bg": "#367FA6",   # Active/selected button background (darker blue)
+        "console_fg":"#333333",   # Text color in console (black)
+        "console_bg":"#F5F5F5",   # Main background color in console (light gray always)
         "active_fg": "#FFFFFF",   # Text color for active elements (white)
         "message": "#FFFF00",     # Notification/copy confirmation color (yellow)
     }

--- a/src/frontend/interface.py
+++ b/src/frontend/interface.py
@@ -110,6 +110,8 @@ class Interface(tk.Tk):
         self.copy_label.config(
             bg=THEMES[self.current_theme]["bg"], fg=THEMES[self.current_theme]["fg"]
         )
+        self.custom_words_raw.config(bg=THEMES[self.current_theme]["bg"], fg=THEMES[self.current_theme]["fg"])
+        self.log_text.config(bg=THEMES[self.current_theme]["bg"], fg=THEMES[self.current_theme]["fg"])
         configure_theme(self, self.current_theme)
         self._update_root_theme()
 

--- a/src/frontend/interface.py
+++ b/src/frontend/interface.py
@@ -108,10 +108,14 @@ class Interface(tk.Tk):
             background=THEMES[self.current_theme]["bg"],
         )
         self.copy_label.config(
-            bg=THEMES[self.current_theme]["bg"], fg=THEMES[self.current_theme]["fg"]
+            bg=THEMES[self.current_theme]["console_bg"], fg=THEMES[self.current_theme]["console_fg"]
         )
-        self.custom_words_raw.config(bg=THEMES[self.current_theme]["bg"], fg=THEMES[self.current_theme]["fg"])
-        self.log_text.config(bg=THEMES[self.current_theme]["bg"], fg=THEMES[self.current_theme]["fg"])
+        self.custom_words_raw.config(
+            bg=THEMES[self.current_theme]["console_bg"], fg=THEMES[self.current_theme]["console_fg"]
+        )
+        self.log_text.config(
+            bg=THEMES[self.current_theme]["console_bg"], fg=THEMES[self.current_theme]["console_fg"]
+        )
         configure_theme(self, self.current_theme)
         self._update_root_theme()
 
@@ -261,7 +265,7 @@ class Interface(tk.Tk):
         """Handle focus in event"""
         if not self.custom_words_modified:
             self.custom_words_raw.delete("1.0", tk.END)
-            self.custom_words_raw.config(fg=THEMES[self.current_theme]["fg"])
+            self.custom_words_raw.config(fg=THEMES[self.current_theme]["console_fg"])
 
     def _on_focus_out(self):
         """Handle focus out event"""


### PR DESCRIPTION
closes  #24 
Added background and foreground color configuration for custom_words_raw and log_text widgets to ensure consistent theming across the interface.